### PR TITLE
use word boundaries for nodesMatching

### DIFF
--- a/src/content/actions.ts
+++ b/src/content/actions.ts
@@ -36,9 +36,15 @@ const nodesMatching = (path?: string, overlayType?: string) => {
       XPathResult.ORDERED_NODE_SNAPSHOT_TYPE,
       null
     );
+
+    const re = new RegExp("\\b" + path.split(" ").join("\\s*\\b") + "\\b", "i");
     for (let i = 0; i < snapshot.snapshotLength; i++) {
       const item = snapshot.snapshotItem(i);
-      if (item !== null && inViewport(item as HTMLElement)) {
+      if (
+        item !== null &&
+        inViewport(item as HTMLElement) &&
+        (item as HTMLElement).innerText.match(re)
+      ) {
         result.push(item);
       }
     }


### PR DESCRIPTION
when searching for nodes matching some text, make sure only whole words
match rather than substrings. this fixes cases where unexpected results
show up for short query strings.