### PR TITLE
Support "show code" and "copy n" thereafter

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,20 +35,17 @@ Commands supported:
     - `go to` (navigates)
 - Tab management
     - `new tab`
-        - `COMMAND_TYPE_CREATE_TAB`
     - `close tab`
     - `next tab`, `previous tab`
     - `(first | second ...) tab`
-        - `COMMAND_TYPE_SWITCH_TAB`
 - Actions
-    - `show (links | inputs)`
-    - `click`
-    - `COMMAND_TYPE_CLICKABLE`
-    - `clear`
-        - `COMMAND_TYPE_CANCEL`
+    - `show (links | inputs | code)` to overlay clickable/copyable elements
+    - `click (text | number)` to click based on text or previous clickables
+    - `use number` to click or copy previous clickables
+    - `COMMAND_TYPE_CLICKABLE` to invalidate alternatives
+    - `clear` to reset overlays
     
 TODO:
 - custom
     - go to tab
-    - google search results
     - searching docs

--- a/src/command-handler.ts
+++ b/src/command-handler.ts
@@ -67,12 +67,12 @@ export class CommandHandler {
   async postMessage(request: string, data?: any): Promise<any> {
     const port = await this.connectToActiveTab!();
 
-    const responsePromise = new Promise((resolve) => {
+    const responsePromise = new Promise((resolve, reject) => {
       port.onMessage.addListener((msg) => {
         resolve(msg);
       });
       port.onDisconnect.addListener((_port: Port) => {
-        resolve({ success: false });
+        reject();
       });
     });
 

--- a/src/content/actions.ts
+++ b/src/content/actions.ts
@@ -44,9 +44,14 @@ const nodesMatching = (path?: string, overlayType?: string) => {
     }
   } else {
     // If no path, then look for all clickable or input elements
-    const elements = document.querySelectorAll(
-      overlayType === "links" ? "a, button" : "input, textarea, div[contenteditable]"
-    );
+    let selectors = "input, textarea, div[contenteditable]";
+    if (overlayType === "links") {
+      selectors = "a, button";
+    } else if (overlayType === "code") {
+      selectors = "pre, code";
+    }
+
+    const elements = document.querySelectorAll(selectors);
     for (let i = 0; i < elements.length; i++) {
       if (inViewport(elements[i] as HTMLElement)) {
         result.push(elements[i]);

--- a/src/content/actions.ts
+++ b/src/content/actions.ts
@@ -54,6 +54,15 @@ const nodesMatching = (path?: string, overlayType?: string) => {
     const elements = document.querySelectorAll(selectors);
     for (let i = 0; i < elements.length; i++) {
       if (inViewport(elements[i] as HTMLElement)) {
+        // if the parent is a pre or code, don't add
+        if (
+          overlayType === "code" &&
+          elements[i].parentElement &&
+          ["PRE", "CODE"].includes(elements[i].parentElement!.tagName)
+        ) {
+          continue;
+        }
+
         result.push(elements[i]);
       }
     }

--- a/src/content/actions.ts
+++ b/src/content/actions.ts
@@ -1,4 +1,5 @@
 import Port = chrome.runtime.Port;
+import Transformer from "./transformer";
 
 const inViewport = (node: HTMLElement) => {
   const bounding = node.getBoundingClientRect();
@@ -151,4 +152,20 @@ export const click = (port: Port, data: { path: string }, clickables: Node[]) =>
     clearOverlays(port);
   }
   return nodes;
+};
+
+export const copyClickable = (port: Port, data: { index: number }, clickables: Node[]) => {
+  if (data.index >= clickables.length) {
+    port.postMessage({ success: false });
+    return;
+  }
+
+  const text = Transformer.getSource(clickables[data.index] as HTMLElement);
+  if (text === null) {
+    port.postMessage({ success: false });
+  } else {
+    navigator.clipboard.writeText(text).then(() => {
+      port.postMessage({ success: true });
+    });
+  }
 };

--- a/src/content/actions.ts
+++ b/src/content/actions.ts
@@ -63,15 +63,14 @@ const nodesMatching = (path?: string, overlayType?: string) => {
 };
 
 export const findClickable = (port: Port, data: { path: string }, clickables: Node[]) => {
-  // If we have a list of clickable elements already and the path is a valid number
-  if (clickables.length && parseInt(data.path, 10) < clickables.length) {
-    port.postMessage({ clickable: true });
+  // If the path is a number, check that it's valid
+  const path = parseInt(data.path, 10);
+  if (!isNaN(path)) {
+    port.postMessage({ clickable: path < clickables.length });
   }
-  // Otherwise, if we have a match for the path
-  else if (nodesMatching(data.path).length) {
-    port.postMessage({ clickable: true });
-  } else {
-    port.postMessage({ clickable: false });
+  // Otherwise, check if we have a match for the path
+  else {
+    port.postMessage({ clickable: nodesMatching(data.path).length });
   }
 };
 

--- a/src/content/actions.ts
+++ b/src/content/actions.ts
@@ -1,5 +1,6 @@
 import Port = chrome.runtime.Port;
 import Transformer from "./transformer";
+import * as utilities from "./utilities";
 
 const inViewport = (node: HTMLElement) => {
   const bounding = node.getBoundingClientRect();
@@ -76,7 +77,7 @@ export const findClickable = (port: Port, data: { path: string }, clickables: No
   // If the path is a number, check that it's valid
   const path = parseInt(data.path, 10);
   if (!isNaN(path)) {
-    port.postMessage({ clickable: path < clickables.length });
+    port.postMessage({ clickable: path - 1 < clickables.length });
   }
   // Otherwise, check if we have a match for the path
   else {
@@ -142,7 +143,7 @@ export const click = (port: Port, data: { path: string }, clickables: Node[]) =>
     }
   }
   // If we have a number that we can click
-  else {
+  else if (pathNumber - 1 < clickables.length) {
     const node = clickables[pathNumber - 1];
     (node as HTMLElement).focus();
     (node as HTMLElement).click();
@@ -168,6 +169,8 @@ export const copyClickable = (port: Port, data: { index: number }, clickables: N
     port.postMessage({ success: false });
   } else {
     navigator.clipboard.writeText(text).then(() => {
+      utilities.showNotification(port, { text: `Copied ${data.index}` });
+      clearOverlays(port);
       port.postMessage({ success: true });
     });
   }

--- a/src/content/actions.ts
+++ b/src/content/actions.ts
@@ -155,12 +155,15 @@ export const click = (port: Port, data: { path: string }, clickables: Node[]) =>
 };
 
 export const copyClickable = (port: Port, data: { index: number }, clickables: Node[]) => {
-  if (data.index >= clickables.length) {
+  // 0-index
+  const index = data.index - 1;
+
+  if (index >= clickables.length) {
     port.postMessage({ success: false });
     return;
   }
 
-  const text = Transformer.getSource(clickables[data.index] as HTMLElement);
+  const text = Transformer.getSource(clickables[index] as HTMLElement);
   if (text === null) {
     port.postMessage({ success: false });
   } else {

--- a/src/content/editor.ts
+++ b/src/content/editor.ts
@@ -1,9 +1,16 @@
 import Transformer from "./transformer";
 import Port = chrome.runtime.Port;
 
+export const editorState = (port: Port, clickableCount: number) => {
+  const source = activeElementSource();
+  const cursor = activeElementCursor();
+
+  port.postMessage({ source, cursor, clickableCount });
+};
+
 // Finds the active element and gets its user-visible source in plaintext.
-export const activeElementSource = (port: Port) => {
-  let activeElementSource: string = "";
+const activeElementSource = () => {
+  let activeElementSource: string | null = null;
   if (document.activeElement) {
     const element = document.activeElement as HTMLElement;
     if (element.tagName === "INPUT") {
@@ -14,11 +21,11 @@ export const activeElementSource = (port: Port) => {
       activeElementSource = Transformer.getSource(element) || "";
     }
   }
-  port.postMessage({ activeElementSource });
+  return activeElementSource;
 };
 
 // Finds the active element and gets the cursor relative to user-visible source.
-export const activeElementCursor = (port: Port) => {
+const activeElementCursor = () => {
   let activeElementCursor = 0;
   if (document.activeElement) {
     const element = document.activeElement as HTMLElement;
@@ -30,7 +37,7 @@ export const activeElementCursor = (port: Port) => {
       activeElementCursor = Transformer.getCursor();
     }
   }
-  port.postMessage({ activeElementCursor });
+  return activeElementCursor;
 };
 
 // Select the active element based on cursor start and end relative to user-visible source.

--- a/src/content/page.ts
+++ b/src/content/page.ts
@@ -60,6 +60,9 @@ chrome.runtime.onConnect.addListener((port) => {
       case "findClickable":
         actions.findClickable(port, msg.data, clickables);
         break;
+      case "copyClickable":
+        actions.copyClickable(port, msg.data, clickables);
+        break;
       /* Utilities */
       case "showNotification":
         utilities.showNotification(port, msg.data);

--- a/src/content/page.ts
+++ b/src/content/page.ts
@@ -13,11 +13,8 @@ chrome.runtime.onConnect.addListener((port) => {
   port.onMessage.addListener((msg) => {
     switch (msg.request) {
       /* Editor */
-      case "activeElementSource":
-        editor.activeElementSource(port);
-        break;
-      case "activeElementCursor":
-        editor.activeElementCursor(port);
+      case "editorState":
+        editor.editorState(port, clickables.length);
         break;
       case "selectActiveElement":
         editor.selectActiveElement(port, msg.data);

--- a/src/content/page.ts
+++ b/src/content/page.ts
@@ -1,7 +1,7 @@
 import * as actions from "./actions";
 import * as editor from "./editor";
 import * as navigator from "./navigator";
-import { click } from "./actions";
+import * as utilities from "./utilities";
 
 // Store list of clickable elements for `show links` and `click`.
 let clickables: Node[] = [];
@@ -59,6 +59,10 @@ chrome.runtime.onConnect.addListener((port) => {
         break;
       case "findClickable":
         actions.findClickable(port, msg.data, clickables);
+        break;
+      /* Utilities */
+      case "showNotification":
+        utilities.showNotification(port, msg.data);
         break;
       default:
         break;

--- a/src/content/transformer.ts
+++ b/src/content/transformer.ts
@@ -25,9 +25,9 @@ export default class Transformer {
       editable = editable.parentElement!;
     }
 
-    // if we didn't find one, return an empty list
+    // if we didn't find one, return the original target
     if (!editable || !editable.hasAttribute("contenteditable")) {
-      return null;
+      return target;
     }
 
     return editable;

--- a/src/content/transformer.ts
+++ b/src/content/transformer.ts
@@ -26,7 +26,7 @@ export default class Transformer {
     }
 
     // if we didn't find one, return an empty list
-    if (!editable.hasAttribute("contenteditable")) {
+    if (!editable || !editable.hasAttribute("contenteditable")) {
       return null;
     }
 

--- a/src/content/utilities.ts
+++ b/src/content/utilities.ts
@@ -1,0 +1,43 @@
+import Port = chrome.runtime.Port;
+
+// Displays a notification
+export const showNotification = (port: Port, data: { text: string }) => {
+  const overlay = document.createElement("div");
+  overlay.innerHTML = data.text;
+  overlay.className = "serenade-overlay";
+  overlay.setAttribute(
+    "style",
+    `
+      position: fixed;
+      z-index: 9999;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      padding: 12px;
+      text-align: center;
+      color: #e6ecf2;
+      background: #1c1c16;
+      border: 1px solid #e6ecf2;
+      border-radius: 6px;
+      opacity: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+      font-size: 16px;
+      transition: opacity 0.5s;
+    `
+  );
+  document.body.appendChild(overlay);
+
+  window.setTimeout(() => {
+    overlay.style.opacity = "0.8";
+  }, 200);
+
+  window.setTimeout(() => {
+    overlay.style.opacity = "0";
+  }, 2000);
+
+  window.setTimeout(() => {
+    overlay.parentNode!.removeChild(overlay);
+  }, 3000);
+
+  port.postMessage({ success: true });
+};

--- a/src/content/utilities.ts
+++ b/src/content/utilities.ts
@@ -4,7 +4,6 @@ import Port = chrome.runtime.Port;
 export const showNotification = (port: Port, data: { text: string }) => {
   const overlay = document.createElement("div");
   overlay.innerHTML = data.text;
-  overlay.className = "serenade-overlay";
   overlay.setAttribute(
     "style",
     `
@@ -36,7 +35,7 @@ export const showNotification = (port: Port, data: { text: string }) => {
   }, 2000);
 
   window.setTimeout(() => {
-    overlay.parentNode!.removeChild(overlay);
+    overlay.parentNode && overlay.parentNode.removeChild(overlay);
   }, 3000);
 
   port.postMessage({ success: true });

--- a/src/handlers/actions-handler.ts
+++ b/src/handlers/actions-handler.ts
@@ -6,26 +6,26 @@ export default class ActionsHandler {
   // These are declared by CommandHandler, which we extend
   postMessage?: (request: string, data?: any) => Promise<any>;
 
-  private async clearOverlays() {
-    await this.postMessage!("clearOverlays");
+  private clearOverlays(): Promise<any> {
+    return this.postMessage!("clearOverlays");
   }
 
   async COMMAND_TYPE_SHOW(data: any): Promise<any> {
     await this.clearOverlays();
 
-    await this.postMessage!("showOverlay", {
+    return this.postMessage!("showOverlay", {
       path: data.path,
       overlayType: data.text,
     });
   }
 
-  async COMMAND_TYPE_CLICK(data: any): Promise<any> {
-    await this.postMessage!("click", {
+  COMMAND_TYPE_CLICK(data: any): Promise<any> {
+    return this.postMessage!("click", {
       path: data.path,
     });
   }
 
-  async COMMAND_TYPE_CLICKABLE(data: any): Promise<any> {
+  COMMAND_TYPE_CLICKABLE(data: any): Promise<any> {
     return new Promise((resolve) => {
       this.postMessage!("findClickable", {
         path: data.path,
@@ -38,7 +38,13 @@ export default class ActionsHandler {
     });
   }
 
-  async COMMAND_TYPE_CANCEL(_data: any): Promise<any> {
-    await this.clearOverlays();
+  COMMAND_TYPE_CANCEL(_data: any): Promise<any> {
+    return this.clearOverlays();
+  }
+
+  COMMAND_TYPE_USE(_data: any): Promise<any> {
+    return this.postMessage!("showNotification", {
+      text: `Copied ${_data.index}`,
+    });
   }
 }

--- a/src/handlers/actions-handler.ts
+++ b/src/handlers/actions-handler.ts
@@ -26,15 +26,19 @@ export default class ActionsHandler {
   }
 
   COMMAND_TYPE_CLICKABLE(data: any): Promise<any> {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       this.postMessage!("findClickable", {
         path: data.path,
-      }).then((data) => {
-        resolve({
-          message: "clickable",
-          data,
+      })
+        .then((data) => {
+          resolve({
+            message: "clickable",
+            data,
+          });
+        })
+        .catch(() => {
+          reject();
         });
-      });
     });
   }
 

--- a/src/handlers/actions-handler.ts
+++ b/src/handlers/actions-handler.ts
@@ -42,10 +42,18 @@ export default class ActionsHandler {
     return this.clearOverlays();
   }
 
-  async COMMAND_TYPE_USE(_data: any): Promise<any> {
-    await this.postMessage!("showNotification", {
-      text: `Copied ${_data.index}`,
+  async COMMAND_TYPE_USE(data: any): Promise<any> {
+    const response = await this.postMessage!("copyClickable", {
+      index: data.index,
     });
-    return this.clearOverlays();
+
+    if (response.success === true) {
+      await this.postMessage!("showNotification", {
+        text: `Copied ${data.index}`,
+      });
+      return this.clearOverlays();
+    }
+
+    return Promise.resolve();
   }
 }

--- a/src/handlers/actions-handler.ts
+++ b/src/handlers/actions-handler.ts
@@ -42,9 +42,10 @@ export default class ActionsHandler {
     return this.clearOverlays();
   }
 
-  COMMAND_TYPE_USE(_data: any): Promise<any> {
-    return this.postMessage!("showNotification", {
+  async COMMAND_TYPE_USE(_data: any): Promise<any> {
+    await this.postMessage!("showNotification", {
       text: `Copied ${_data.index}`,
     });
+    return this.clearOverlays();
   }
 }

--- a/src/handlers/actions-handler.ts
+++ b/src/handlers/actions-handler.ts
@@ -46,18 +46,9 @@ export default class ActionsHandler {
     return this.clearOverlays();
   }
 
-  async COMMAND_TYPE_USE(data: any): Promise<any> {
-    const response = await this.postMessage!("copyClickable", {
+  COMMAND_TYPE_USE(data: any): Promise<any> {
+    return this.postMessage!("useClickable", {
       index: data.index,
     });
-
-    if (response.success === true) {
-      await this.postMessage!("showNotification", {
-        text: `Copied ${data.index}`,
-      });
-      return this.clearOverlays();
-    }
-
-    return Promise.resolve();
   }
 }

--- a/src/handlers/editor-handler.ts
+++ b/src/handlers/editor-handler.ts
@@ -10,29 +10,38 @@ export default class EditorHandler {
 
   async COMMAND_TYPE_GET_EDITOR_STATE(_data: any): Promise<any> {
     return new Promise((resolve) => {
-      this.postMessage!("editorState").then((response) => {
-        if (response.source === null) {
+      this.postMessage!("editorState")
+        .then((response) => {
+          if (response.source === null) {
+            resolve({
+              message: "editorState",
+              data: {
+                useSystemInsert: true,
+                clickableCount: response.clickableCount,
+              },
+            });
+          } else {
+            resolve({
+              message: "editorState",
+              data: {
+                source: response.source,
+                cursor: response.cursor,
+                clickableCount: response.clickableCount,
+                filename: "",
+                files: [],
+                roots: [],
+              },
+            });
+          }
+        })
+        .catch(() =>
           resolve({
             message: "editorState",
             data: {
               useSystemInsert: true,
-              clickableCount: response.clickableCount,
             },
-          });
-        } else {
-          resolve({
-            message: "editorState",
-            data: {
-              source: response.source,
-              cursor: response.cursor,
-              clickableCount: response.clickableCount,
-              filename: "",
-              files: [],
-              roots: [],
-            },
-          });
-        }
-      });
+          })
+        );
     });
   }
 
@@ -42,14 +51,20 @@ export default class EditorHandler {
 
   async COMMAND_TYPE_PASTE(_data: any): Promise<any> {
     return new Promise((resolve) => {
-      this.postMessage!("getClipboard").then((data) => {
-        resolve({
-          message: "insertText",
-          data: {
-            text: data.text,
-          },
-        });
-      });
+      this.postMessage!("getClipboard")
+        .then((data) => {
+          resolve({
+            message: "insertText",
+            data: {
+              text: data.text,
+            },
+          });
+        })
+        .catch(() =>
+          resolve({
+            message: "paste",
+          })
+        );
     });
   }
 

--- a/src/handlers/editor-handler.ts
+++ b/src/handlers/editor-handler.ts
@@ -10,28 +10,28 @@ export default class EditorHandler {
 
   async COMMAND_TYPE_GET_EDITOR_STATE(_data: any): Promise<any> {
     return new Promise((resolve) => {
-      this.postMessage!("activeElementSource").then((sourceResponse) => {
-        this.postMessage!("activeElementCursor").then((cursorResponse) => {
-          if (sourceResponse === null) {
-            resolve({
-              message: "editorState",
-              data: {
-                useSystemInsert: true,
-              },
-            });
-          } else {
-            resolve({
-              message: "editorState",
-              data: {
-                source: sourceResponse.activeElementSource,
-                cursor: cursorResponse.activeElementCursor,
-                filename: "",
-                files: [],
-                roots: [],
-              },
-            });
-          }
-        });
+      this.postMessage!("editorState").then((response) => {
+        if (response.source === null) {
+          resolve({
+            message: "editorState",
+            data: {
+              useSystemInsert: true,
+              clickableCount: response.clickableCount,
+            },
+          });
+        } else {
+          resolve({
+            message: "editorState",
+            data: {
+              source: response.activeElementSource,
+              cursor: response.activeElementCursor,
+              clickableCount: response.clickableCount,
+              filename: "",
+              files: [],
+              roots: [],
+            },
+          });
+        }
       });
     });
   }

--- a/src/handlers/editor-handler.ts
+++ b/src/handlers/editor-handler.ts
@@ -23,8 +23,8 @@ export default class EditorHandler {
           resolve({
             message: "editorState",
             data: {
-              source: response.activeElementSource,
-              cursor: response.activeElementCursor,
+              source: response.source,
+              cursor: response.cursor,
               clickableCount: response.clickableCount,
               filename: "",
               files: [],


### PR DESCRIPTION
Shows overlay of clickable or copy-able elements. Clicks or copies with use command and shows notification on copy. Falls back to system paste when needed, and catches failed reading of editor state better (for example, in the Developer Tools console).