### PR TITLE
Inject JS into page for reading local variables

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -24,8 +24,11 @@
   "content_scripts": [
     {
       "matches": ["*://*/*"],
-      "js": ["build/page.js"]
+      "js": ["build/content.js", "build/inject.js"]
     }
+  ],
+  "web_accessible_resources": [
+    "build/page.js"
   ],
   "permissions": ["tabs", "*://*/*"]
 }

--- a/src/content/editor.ts
+++ b/src/content/editor.ts
@@ -11,6 +11,17 @@ export const editorState = (port: Port, clickableCount: number) => {
 
 // Finds the active element and gets its user-visible source in plaintext.
 const activeElementSource = () => {
+  document.addEventListener(
+    "serenade-chrome-send-codemirror",
+    (e) => {
+      console.log((e as any).detail);
+    },
+    {
+      once: true,
+    }
+  );
+  document.dispatchEvent(new CustomEvent("serenade-chrome-request-codemirror"));
+
   let activeElementSource: string | null = null;
   if (document.activeElement) {
     const element = document.activeElement as HTMLElement;

--- a/src/inject.js
+++ b/src/inject.js
@@ -1,0 +1,15 @@
+/**
+ * injectScript - Inject internal script to available access to the `window`
+ *
+ * @param  {type} file_path Local path of the internal script.
+ * @param  {type} tag The tag as string, where the script will be append (default: 'body').
+ * @see    {@link http://stackoverflow.com/questions/20499994/access-window-variable-from-content-script}
+ */
+function injectScript(file_path, tag) {
+  var node = document.getElementsByTagName(tag)[0];
+  var script = document.createElement('script');
+  script.setAttribute('type', 'text/javascript');
+  script.setAttribute('src', file_path);
+  node.appendChild(script);
+}
+injectScript(chrome.extension.getURL('build/page.js'), 'body');

--- a/src/page.ts
+++ b/src/page.ts
@@ -1,0 +1,13 @@
+document.addEventListener("serenade-chrome-request-codemirror", () => {
+  const codeMirror = (document.querySelector(".CodeMirror") as any)?.CodeMirror;
+
+  document.dispatchEvent(
+    new CustomEvent("serenade-chrome-send-codemirror", {
+      detail: {
+        // codeMirror: codeMirror, // sending complex objects don't seem to work?
+        codeMirrorValue: codeMirror?.doc.getValue() as string,
+        codeMirrorCursor: codeMirror?.doc.getCursor(),
+      },
+    })
+  );
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,9 @@ const config = {
   target: "web",
   entry: {
     extension: "./src/extension.ts",
-    page: "./src/content/page-command-handler.ts",
+    inject: "./src/inject.js",
+    content: "./src/content/page-command-handler.ts",
+    page: "./src/page.ts",
   },
   output: {
     path: path.resolve(__dirname, "build"),
@@ -30,7 +32,7 @@ const config = {
 
 module.exports = (env, argv) => {
   if (argv.mode === 'development') {
-    config.devtool = 'eval';
+    config.devtool = 'source-map';
   }
 
   return config;


### PR DESCRIPTION
From https://gist.github.com/devjin0617/3e8d72d94c1b9e69690717a219644c7a and other StackOverflow posts, found a way to run scripts within the actual page of each tab before sending it back to our extension, so we can use CodeMirror's APIs. Hopefully this won't trigger more security scrutiny from Chrome's extension moderation during the publishing process lately, but it seems pretty simple.﻿
