### PR TITLE
Add accessible elements with ARIA roles to selectors for show commands

### DIFF
--- a/src/content/actions.ts
+++ b/src/content/actions.ts
@@ -56,9 +56,9 @@ const nodesMatching = (path?: string, overlayType?: string) => {
     }
   } else {
     // If no path, then look for all clickable or input elements
-    let selectors = "input, textarea, div[contenteditable]";
+    let selectors = "input, textarea, div[contenteditable], [role=\"checkbox\"], [role=\"radio\"]";
     if (overlayType === "links") {
-      selectors = "a, button";
+      selectors = "a, button, [role=\"link\"], [role=\"button\"]";
     } else if (overlayType === "code") {
       selectors = "pre, code";
     }


### PR DESCRIPTION
## Description of proposed changes
* Modify selectors used by "show xyz" commands to include elements with relevant ARIA roles.
  * Modified selectors for "show inputs" to include ARIA-accessible checkboxes and radio buttons
  * Modified selectors for "show links" to include ARIA-accessible links and buttons
* The main reason to suggest this change is for sites that implement significant portions of their UI with ARIA-accessible elements instead of semantic elements (gmail inbox, for example).

## Testing completed
* Used listed cases to verify the "show" commands now find the aforementioned ARIA-accessible elements.
* Verified that the "use #" command works with properly-implemented elements.
* Tested with Chrome 89 and Mac OS Big Sur 11.2.1

### Test cases
* [Checkboxes](https://www.w3.org/TR/wai-aria-practices-1.1/examples/checkbox/checkbox-1/checkbox-1.html)
* [Radio buttons](https://www.w3.org/TR/wai-aria-practices-1.1/examples/radio/radio-1/radio-1.html)
* [Links](https://www.w3.org/TR/wai-aria-practices-1.1/examples/link/link.html)
* [Buttons](https://www.w3.org/TR/wai-aria-practices-1.1/examples/button/button.html)

## A conceivable concern
I could see somebody having the concern that some elements using ARIA roles may not be properly implemented (with event handlers) such that the follow up command "use #" may not work as the user intends. Hopefully this is not the case, seeing as this is [the number 1 principle](https://www.w3.org/TR/wai-aria-practices-1.1/#no_aria_better_bad_aria) of ARIA. If it is the case, there is nothing Serenade can do about it. Consider that semantic elements technically have the same vulnerability if the developer overrides the default event handler behaviors. For this reason I do not think this concern should get in the way of adding this change to Serenade.