### PR TITLE
add load eventListener instead of overriding onload

### DIFF
--- a/src/page.ts
+++ b/src/page.ts
@@ -93,9 +93,9 @@ document.addEventListener("DOMContentLoaded", (_e: any) => {
   monacoListener();
 });
 
-window.onload = (_e: any) => {
+window.addEventListener("load", (_e: any) => {
   monacoListener();
-};
+});
 
 const getMonaco = () => {
   let focused: any | null = null;


### PR DESCRIPTION
Avoids overriding another page's `onload` event response with function to add a listener for new Monaco instances.