### PR TITLE
Address bar type + use bugfix

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2
+}

--- a/src/content/command-handler.ts
+++ b/src/content/command-handler.ts
@@ -2,10 +2,7 @@ import Tab from "./tab";
 import Port = chrome.runtime.Port;
 
 export default class CommandHandler {
-  public async applyDiff(data: {
-    source: string;
-    cursor: number;
-  }): Promise<any> {
+  public async applyDiff(data: { source: string; cursor: number }): Promise<any> {
     return { success: await Tab.editor.applyDiff(data.source, data.cursor) };
   }
 
@@ -15,9 +12,10 @@ export default class CommandHandler {
       const cursor = await Tab.editor.activeElementCursor();
       const filename = await Tab.editor.activeElementFilename();
       const clickableCount = Tab.overlay.clickables.length;
-      return { source, cursor, filename, clickableCount };
+      const error = source == null;
+      return { source, cursor, filename, clickableCount, error };
     } else {
-      return { source: null, cursor: null, filename: null, clickableCount: 0 };
+      return { filename: "serenade-chrome-address-bar", error: true };
     }
   }
 
@@ -36,15 +34,9 @@ export default class CommandHandler {
     return { success: true };
   }
 
-  public async selectActiveElement(data: {
-    cursor: number;
-    cursorEnd: number;
-  }): Promise<any> {
+  public async selectActiveElement(data: { cursor: number; cursorEnd: number }): Promise<any> {
     return {
-      success: await Tab.editor.selectActiveElement(
-        data.cursor,
-        data.cursorEnd
-      ),
+      success: await Tab.editor.selectActiveElement(data.cursor, data.cursorEnd),
     };
   }
 

--- a/src/content/command-handler.ts
+++ b/src/content/command-handler.ts
@@ -2,32 +2,15 @@ import Tab from "./tab";
 import Port = chrome.runtime.Port;
 
 export default class CommandHandler {
-  focus: boolean;
-
-  constructor() {
-    this.focus = true;
-  }
-
-  public async applyDiff(data: { source: string; cursor: number }): Promise<any> {
+  public async applyDiff(data: {
+    source: string;
+    cursor: number;
+  }): Promise<any> {
     return { success: await Tab.editor.applyDiff(data.source, data.cursor) };
   }
 
   public async editorState(): Promise<any> {
-    window.addEventListener(
-      "focusout",
-      (_e) => {
-        this.focus = false;
-      },
-      { once: true }
-    );
-    window.addEventListener(
-      "focusin",
-      (_e) => {
-        this.focus = true;
-      },
-      { once: true }
-    );
-    if (this.focus) {
+    if (document.hasFocus()) {
       const source = await Tab.editor.activeElementSource();
       const cursor = await Tab.editor.activeElementCursor();
       const filename = await Tab.editor.activeElementFilename();
@@ -53,8 +36,16 @@ export default class CommandHandler {
     return { success: true };
   }
 
-  public async selectActiveElement(data: { cursor: number; cursorEnd: number }): Promise<any> {
-    return { success: await Tab.editor.selectActiveElement(data.cursor, data.cursorEnd) };
+  public async selectActiveElement(data: {
+    cursor: number;
+    cursorEnd: number;
+  }): Promise<any> {
+    return {
+      success: await Tab.editor.selectActiveElement(
+        data.cursor,
+        data.cursorEnd
+      ),
+    };
   }
 
   public async setCursor(data: { cursor: number }): Promise<any> {

--- a/src/content/editor.ts
+++ b/src/content/editor.ts
@@ -1,7 +1,6 @@
 import Tab from "./tab";
 
 export default class Editor {
-
   activeElementIsCodeMirror(): boolean {
     const codeMirrorNodes = document.querySelectorAll(".CodeMirror");
     let isCodeMirror = false;
@@ -11,7 +10,7 @@ export default class Editor {
       }
     });
     return isCodeMirror;
-  };
+  }
 
   activeElementIsMonaco = () => {
     const monacoNodes = document.querySelectorAll(".monaco-editor");
@@ -48,7 +47,7 @@ export default class Editor {
     });
     document.dispatchEvent(new CustomEvent("serenade-chrome-request-monaco"));
     return monaco;
-  };
+  }
 
   // Finds the active element and gets its user-visible source in plaintext.
   async activeElementSource() {
@@ -66,12 +65,12 @@ export default class Editor {
         } else if (element.tagName === "TEXTAREA") {
           activeElementSource = (element as HTMLTextAreaElement).value;
         } else if (element.isContentEditable) {
-          activeElementSource = Tab.transformer.getSource(element) || "";
+          activeElementSource = Tab.transformer.getSource(element);
         }
       }
     }
     return activeElementSource;
-  };
+  }
 
   // Finds the active element and gets the cursor relative to user-visible source.
   async activeElementCursor(): Promise<number | null> {
@@ -94,7 +93,7 @@ export default class Editor {
       }
     }
     return activeElementCursor;
-  };
+  }
 
   // Finds the active element and gets the cursor relative to user-visible source.
   async activeElementFilename(): Promise<string> {
@@ -107,12 +106,10 @@ export default class Editor {
       }
     }
     return activeElementFilename;
-  };
+  }
 
   // Select the active element based on cursor start and end relative to user-visible source.
-  public async selectActiveElement(
-    cursorStart: number, cursorEnd: number
-  ): Promise<boolean> {
+  public async selectActiveElement(cursorStart: number, cursorEnd: number): Promise<boolean> {
     if (document.activeElement) {
       let success = false;
       let status = new Promise((resolve) => {
@@ -158,7 +155,7 @@ export default class Editor {
       }
     }
     return true;
-  };
+  }
 
   // Select the active element and set the cursor on it
   public async setCursor(cursor: number): Promise<void> {
@@ -203,7 +200,7 @@ export default class Editor {
         }
       }
     }
-  };
+  }
 
   public async applyDiff(source: string, cursor: number) {
     let success = false;
@@ -238,5 +235,5 @@ export default class Editor {
       success = (await status) as boolean;
     }
     return success;
-  };
+  }
 }

--- a/src/handlers/editor-handler.ts
+++ b/src/handlers/editor-handler.ts
@@ -22,6 +22,7 @@ export default class EditorHandler {
               cursor: response.cursor,
               clickableCount: response.clickableCount,
               filename: response.filename,
+              error: response.error,
               files: [],
               roots: [],
             },
@@ -32,6 +33,7 @@ export default class EditorHandler {
             message: "editorState",
             data: {
               useSystemInsert: true,
+              error: true,
             },
           })
         );


### PR DESCRIPTION
Added event listeners for "focusout" and "focusin" events, so if the user clicks away from the document pane to click on the address bar, we will use the proper methods to get the editor state.