### PR TITLE
fix behavior of "show links" when divs are embedded inside anchor tags

### DIFF
--- a/src/content/overlay.ts
+++ b/src/content/overlay.ts
@@ -66,7 +66,11 @@ export default class Overlay {
       }
       const elements = document.querySelectorAll(selectors);
       for (let i = 0; i < elements.length; i++) {
-        if (this.inViewport(elements[i] as HTMLElement)) {
+        let element = elements[i] as HTMLElement;
+        if (element.tagName == "A" && element.firstElementChild?.tagName == "DIV") {
+          element = element.firstElementChild as HTMLElement;
+        }
+        if (this.inViewport(element)) {
           // if the parent is a pre or code, don't add
           if (
             overlayType === "code" &&
@@ -76,7 +80,7 @@ export default class Overlay {
             continue;
           }
 
-          result.push(elements[i]);
+          result.push(element);
         }
       }
     }


### PR DESCRIPTION
Sites with div elements embedded in anchor elements would sometimes place overlays in the wrong position. For example saying "show links" [here](https://jupyter.org/try) would cluster all of the overlay numbers for the card links away from the cards.

This change checks if each anchor tag found on the page has a div child, and if so use that div to determine where the overlay should go rather than the anchor tag.