### PR TITLE
Send current URL with editor state, CSS selector custom commands  [SER-896]

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Serenade for Chrome",
-  "version": "1.3.1",
+  "version": "1.4.1",
   "description": "Navigate the web with voice.",
   "icons": {
     "16": "img/icon_default/16x16.png",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Serenade for Chrome",
-  "version": "1.4.1",
+  "version": "1.4.0",
   "description": "Navigate the web with voice.",
   "icons": {
     "16": "img/icon_default/16x16.png",

--- a/src/content/command-handler.ts
+++ b/src/content/command-handler.ts
@@ -69,18 +69,25 @@ export default class CommandHandler {
   public async click(data: any): Promise<any> {
     if (data.path) {
       Tab.overlay.click(data.path);
-    } else if (data.query) {
+    }
+    return { success: true };
+  }
+
+  public async domClick(data: any): Promise<any> {
+    if (data.query) {
       Tab.overlay.domClick(data.query);
     }
     return { success: true };
   }
 
-  public async focus(data: any): Promise<any> {
+  public async domFocus(data: any): Promise<any> {
     Tab.overlay.domFocus(data.query);
+    return { success: true };
   }
 
-  public async blur(data: any): Promise<any> {
+  public async domBlur(data: any): Promise<any> {
     Tab.overlay.domBlur(data.query);
+    return { success: true };
   }
 
   public async useClickable(data: any): Promise<any> {

--- a/src/content/command-handler.ts
+++ b/src/content/command-handler.ts
@@ -7,15 +7,16 @@ export default class CommandHandler {
   }
 
   public async editorState(): Promise<any> {
+    const url = window.location.toString();
     if (document.hasFocus()) {
       const source = await Tab.editor.activeElementSource();
       const cursor = await Tab.editor.activeElementCursor();
       const filename = await Tab.editor.activeElementFilename();
       const clickableCount = Tab.overlay.clickables.length;
       const error = source == null;
-      return { source, cursor, filename, clickableCount, error };
+      return { source, cursor, filename, clickableCount, error, url };
     } else {
-      return { filename: "", error: true };
+      return { filename: "", error: true, url: url };
     }
   }
 

--- a/src/content/command-handler.ts
+++ b/src/content/command-handler.ts
@@ -69,6 +69,8 @@ export default class CommandHandler {
   public async click(data: any): Promise<any> {
     if (data.path) {
       Tab.overlay.click(data.path);
+    } else if (data.text) {
+      Tab.overlay.DOMClick(data.text);
     }
     return { success: true };
   }

--- a/src/content/command-handler.ts
+++ b/src/content/command-handler.ts
@@ -76,11 +76,11 @@ export default class CommandHandler {
   }
 
   public async focus(data: any): Promise<any> {
-    Tab.overlay.focus(data.query);
+    Tab.overlay.DOMFocus(data.query);
   }
 
   public async blur(data: any): Promise<any> {
-    Tab.overlay.blur(data.query);
+    Tab.overlay.DOMBlur(data.query);
   }
 
   public async useClickable(data: any): Promise<any> {

--- a/src/content/command-handler.ts
+++ b/src/content/command-handler.ts
@@ -70,17 +70,17 @@ export default class CommandHandler {
     if (data.path) {
       Tab.overlay.click(data.path);
     } else if (data.query) {
-      Tab.overlay.DOMClick(data.query);
+      Tab.overlay.domClick(data.query);
     }
     return { success: true };
   }
 
   public async focus(data: any): Promise<any> {
-    Tab.overlay.DOMFocus(data.query);
+    Tab.overlay.domFocus(data.query);
   }
 
   public async blur(data: any): Promise<any> {
-    Tab.overlay.DOMBlur(data.query);
+    Tab.overlay.domBlur(data.query);
   }
 
   public async useClickable(data: any): Promise<any> {

--- a/src/content/command-handler.ts
+++ b/src/content/command-handler.ts
@@ -16,7 +16,7 @@ export default class CommandHandler {
       const error = source == null;
       return { source, cursor, filename, clickableCount, error, url };
     } else {
-      return { filename: "", error: true, url: url };
+      return { filename: "", error: true, url };
     }
   }
 

--- a/src/content/command-handler.ts
+++ b/src/content/command-handler.ts
@@ -69,10 +69,18 @@ export default class CommandHandler {
   public async click(data: any): Promise<any> {
     if (data.path) {
       Tab.overlay.click(data.path);
-    } else if (data.text) {
-      Tab.overlay.DOMClick(data.text);
+    } else if (data.query) {
+      Tab.overlay.DOMClick(data.query);
     }
     return { success: true };
+  }
+
+  public async focus(data: any): Promise<any> {
+    Tab.overlay.focus(data.query);
+  }
+
+  public async blur(data: any): Promise<any> {
+    Tab.overlay.blur(data.query);
   }
 
   public async useClickable(data: any): Promise<any> {

--- a/src/content/overlay.ts
+++ b/src/content/overlay.ts
@@ -167,13 +167,7 @@ export default class Overlay {
     // If we have a number that we can click
     if (pathNumber - 1 < this.clickables.length) {
       const node = this.clickables[pathNumber - 1];
-      if ((node as HTMLElement).className.includes("CodeMirror")) {
-        (node as HTMLElement).getElementsByTagName("textarea")[0].focus();
-        (node as HTMLElement).getElementsByTagName("textarea")[0].click();
-      } else {
-        (node as HTMLElement).focus();
-        (node as HTMLElement).click();
-      }
+      this.clickNode(node);
     }
     this.clearOverlays();
   }
@@ -181,8 +175,7 @@ export default class Overlay {
   public DOMClick(query: string) {
     const node = document.querySelector(query);
     if (node !== null) {
-      (node as HTMLElement).focus();
-      (node as HTMLElement).click();
+      this.clickNode(node);
     } else {
       return;
     }

--- a/src/content/overlay.ts
+++ b/src/content/overlay.ts
@@ -187,6 +187,31 @@ export default class Overlay {
       (node as HTMLElement).focus();
       (node as HTMLElement).click();
     } else {
+      return;
+    }
+  }
+
+  public focus(query: string) {
+    const nodes = document.querySelectorAll(query);
+    if (nodes.length === 0) {
+      return;
+    } else if (nodes.length === 1) {
+      const node: Element = nodes[0];
+      (node as HTMLElement).focus();
+    } else {
+      return;
+    }
+  }
+
+  public blur(query: string) {
+    const nodes = document.querySelectorAll(query);
+    if (nodes.length === 0) {
+      return;
+    } else if (nodes.length === 1) {
+      const node: Element = nodes[0];
+      (node as HTMLElement).blur();
+    } else {
+      return;
     }
   }
 

--- a/src/content/overlay.ts
+++ b/src/content/overlay.ts
@@ -188,7 +188,7 @@ export default class Overlay {
     }
   }
 
-  public focus(query: string) {
+  public DOMFocus(query: string) {
     const node = document.querySelector(query);
     if (node !== null) {
       (node as HTMLElement).focus();
@@ -197,7 +197,7 @@ export default class Overlay {
     }
   }
 
-  public blur(query: string) {
+  public DOMBlur(query: string) {
     const node = document.querySelector(query);
     if (node !== null) {
       (node as HTMLElement).blur();

--- a/src/content/overlay.ts
+++ b/src/content/overlay.ts
@@ -179,11 +179,8 @@ export default class Overlay {
   }
 
   public DOMClick(query: string) {
-    const nodes = document.querySelectorAll(query);
-    if (nodes.length === 0) {
-      return;
-    } else if (nodes.length === 1) {
-      const node: Element = nodes[0];
+    const node = document.querySelector(query);
+    if (node !== null) {
       (node as HTMLElement).focus();
       (node as HTMLElement).click();
     } else {
@@ -192,11 +189,8 @@ export default class Overlay {
   }
 
   public focus(query: string) {
-    const nodes = document.querySelectorAll(query);
-    if (nodes.length === 0) {
-      return;
-    } else if (nodes.length === 1) {
-      const node: Element = nodes[0];
+    const node = document.querySelector(query);
+    if (node !== null) {
       (node as HTMLElement).focus();
     } else {
       return;
@@ -204,11 +198,8 @@ export default class Overlay {
   }
 
   public blur(query: string) {
-    const nodes = document.querySelectorAll(query);
-    if (nodes.length === 0) {
-      return;
-    } else if (nodes.length === 1) {
-      const node: Element = nodes[0];
+    const node = document.querySelector(query);
+    if (node !== null) {
       (node as HTMLElement).blur();
     } else {
       return;

--- a/src/content/overlay.ts
+++ b/src/content/overlay.ts
@@ -137,6 +137,16 @@ export default class Overlay {
     }
   }
 
+  private clickNode(node: Node) {
+    if ((node as HTMLElement).className.includes("CodeMirror")) {
+      (node as HTMLElement).getElementsByTagName("textarea")[0].focus();
+      (node as HTMLElement).getElementsByTagName("textarea")[0].click();
+    } else {
+      (node as HTMLElement).focus();
+      (node as HTMLElement).click();
+    }
+  }
+
   public click(path: string) {
     const pathNumber = parseInt(path, 10);
     // If we are clicking a text path
@@ -145,13 +155,7 @@ export default class Overlay {
       // auto-execute
       if (this.clickables.length === 1) {
         const node = this.clickables[0];
-        if ((node as HTMLElement).className.includes("CodeMirror")) {
-          (node as HTMLElement).getElementsByTagName("textarea")[0].focus();
-          (node as HTMLElement).getElementsByTagName("textarea")[0].click();
-        } else {
-          (node as HTMLElement).focus();
-          (node as HTMLElement).click();
-        }
+        this.clickNode(node);
         this.clearOverlays();
         return;
       } else {
@@ -172,6 +176,18 @@ export default class Overlay {
       }
     }
     this.clearOverlays();
+  }
+
+  public DOMClick(query: string) {
+    const nodes = document.querySelectorAll(query);
+    if (nodes.length === 0) {
+      return;
+    } else if (nodes.length === 1) {
+      const node: Element = nodes[0];
+      (node as HTMLElement).focus();
+      (node as HTMLElement).click();
+    } else {
+    }
   }
 
   public async copyClickable(index: number): Promise<boolean> {

--- a/src/content/overlay.ts
+++ b/src/content/overlay.ts
@@ -138,12 +138,13 @@ export default class Overlay {
   }
 
   private clickNode(node: Node) {
-    if ((node as HTMLElement).className.includes("CodeMirror")) {
-      (node as HTMLElement).getElementsByTagName("textarea")[0].focus();
-      (node as HTMLElement).getElementsByTagName("textarea")[0].click();
+    const element = node as HTMLElement;
+    if (element.className.includes("CodeMirror")) {
+      element.getElementsByTagName("textarea")[0].focus();
+      element.getElementsByTagName("textarea")[0].click();
     } else {
-      (node as HTMLElement).focus();
-      (node as HTMLElement).click();
+      element.focus();
+      element.click();
     }
   }
 
@@ -172,7 +173,7 @@ export default class Overlay {
     this.clearOverlays();
   }
 
-  public DOMClick(query: string) {
+  public domClick(query: string) {
     const node = document.querySelector(query);
     if (node !== null) {
       this.clickNode(node);
@@ -181,19 +182,19 @@ export default class Overlay {
     }
   }
 
-  public DOMFocus(query: string) {
-    const node = document.querySelector(query);
-    if (node !== null) {
-      (node as HTMLElement).focus();
+  public domFocus(query: string) {
+    const element = document.querySelector(query) as HTMLElement;
+    if (element !== null) {
+      element.focus();
     } else {
       return;
     }
   }
 
-  public DOMBlur(query: string) {
-    const node = document.querySelector(query);
-    if (node !== null) {
-      (node as HTMLElement).blur();
+  public domBlur(query: string) {
+    const element = document.querySelector(query) as HTMLElement;
+    if (element !== null) {
+      element.blur();
     } else {
       return;
     }

--- a/src/handlers/actions-handler.ts
+++ b/src/handlers/actions-handler.ts
@@ -23,6 +23,7 @@ export default class ActionsHandler {
   COMMAND_TYPE_CLICK(data: any): Promise<any> {
     return this.resolvePostMessage!("click", {
       path: data.path,
+      text: data.text,
     });
   }
 

--- a/src/handlers/actions-handler.ts
+++ b/src/handlers/actions-handler.ts
@@ -48,8 +48,13 @@ export default class ActionsHandler {
   }
 
   COMMAND_TYPE_FOCUS(data: any): Promise<any> {
-    return this.resolvePostMessage!(data.direction, {
-      query: data.text,
+    if (data.direction) {
+      return this.resolvePostMessage!(data.direction, {
+        query: data.text,
+      });
+    }
+    return new Promise((resolve) => {
+      resolve();
     });
   }
 

--- a/src/handlers/actions-handler.ts
+++ b/src/handlers/actions-handler.ts
@@ -23,7 +23,7 @@ export default class ActionsHandler {
   COMMAND_TYPE_CLICK(data: any): Promise<any> {
     return this.resolvePostMessage!("click", {
       path: data.path,
-      text: data.text,
+      query: data.text,
     });
   }
 
@@ -45,6 +45,12 @@ export default class ActionsHandler {
 
   COMMAND_TYPE_CANCEL(_data: any): Promise<any> {
     return this.clearOverlays();
+  }
+
+  COMMAND_TYPE_FOCUS(data: any): Promise<any> {
+    return this.resolvePostMessage!(data.direction, {
+      query: data.text,
+    });
   }
 
   COMMAND_TYPE_USE(data: any): Promise<any> {

--- a/src/handlers/actions-handler.ts
+++ b/src/handlers/actions-handler.ts
@@ -21,9 +21,13 @@ export default class ActionsHandler {
   }
 
   COMMAND_TYPE_CLICK(data: any): Promise<any> {
+    if (data.text) {
+      return this.resolvePostMessage!("domClick", {
+        query: data.text,
+      });
+    }
     return this.resolvePostMessage!("click", {
       path: data.path,
-      query: data.text,
     });
   }
 

--- a/src/handlers/actions-handler.ts
+++ b/src/handlers/actions-handler.ts
@@ -21,11 +21,6 @@ export default class ActionsHandler {
   }
 
   COMMAND_TYPE_CLICK(data: any): Promise<any> {
-    if (data.text) {
-      return this.resolvePostMessage!("domClick", {
-        query: data.text,
-      });
-    }
     return this.resolvePostMessage!("click", {
       path: data.path,
     });
@@ -51,14 +46,21 @@ export default class ActionsHandler {
     return this.clearOverlays();
   }
 
-  COMMAND_TYPE_FOCUS(data: any): Promise<any> {
-    if (data.direction) {
-      return this.resolvePostMessage!(data.direction, {
-        query: data.text,
-      });
-    }
-    return new Promise((resolve) => {
-      resolve();
+  COMMAND_TYPE_DOM_BLUR(data: any): Promise<any> {
+    return this.resolvePostMessage!("domBlur", {
+      query: data.text,
+    });
+  }
+
+  COMMAND_TYPE_DOM_CLICK(data: any): Promise<any> {
+    return this.resolvePostMessage!("domClick", {
+      query: data.text,
+    });
+  }
+
+  COMMAND_TYPE_DOM_FOCUS(data: any): Promise<any> {
+    return this.resolvePostMessage!("domFocus", {
+      query: data.text,
     });
   }
 

--- a/src/handlers/editor-handler.ts
+++ b/src/handlers/editor-handler.ts
@@ -34,6 +34,7 @@ export default class EditorHandler {
           error: response.error,
           files: [],
           roots: [],
+          url: response.url,
         },
       };
     } catch (e) {


### PR DESCRIPTION
Relevant PRs in other repos:
- Client: https://github.com/serenadeai/client/pull/121
- Server: https://github.com/serenadeai/server/pull/468

Changes:
- Send back current tab's URL with the editor state
- Add responses to `COMMAND_TYPE_CLICK` and `COMMAND_TYPE_FOCUS` sent by client for `DOMClick`, `DOMFocus`, and `DOMBlur` calls
        - If the `COMMAND_TYPE_CLICK` includes a `query` attribute, we use the `DOMClick` function. Otherwise, we use the regular `click` function.
	- Since the client sets the direction in `COMMAND_TYPE_FOCUS` for focus/blur commands, if no direction is included in the focus command, we know it's meant to be a system focus command. Therefore, we do a no-op. If the direction is set, we use the direction to call either `focus` or `blur` in `command-handler.ts`

Also did a small refactor to condense some reused code around clicking specific nodes.