### PR TITLE
Fix "last tab" command

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Serenade for Chrome",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Navigate the web with voice.",
   "icons": {
     "16": "img/icon_default/16x16.png",

--- a/src/handlers/tab-handler.ts
+++ b/src/handlers/tab-handler.ts
@@ -65,7 +65,7 @@ export default class TabHandler {
   }
 
   async COMMAND_TYPE_SWITCH_TAB(data: any): Promise<any> {
-    if (data.index < 0) {
+    if (data.index <= 0) {
       chrome.tabs.query({ lastFocusedWindow: true }, (tabs) => {
         chrome.tabs.update(tabs[tabs.length - 1].id!, { active: true }, (_v: any) => {});
       });

--- a/src/handlers/tab-handler.ts
+++ b/src/handlers/tab-handler.ts
@@ -65,14 +65,13 @@ export default class TabHandler {
   }
 
   async COMMAND_TYPE_SWITCH_TAB(data: any): Promise<any> {
-    if (data.index) {
-      chrome.tabs.query({ index: data.index - 1, lastFocusedWindow: true }, (tab) => {
-        chrome.tabs.update(tab[0].id!, { active: true }, (_v: any) => {});
-      });
-    } else {
-      // Undefined index corresponds to last tab (because protobuf does not send default values)
+    if (data.index < 0) {
       chrome.tabs.query({ lastFocusedWindow: true }, (tabs) => {
         chrome.tabs.update(tabs[tabs.length - 1].id!, { active: true }, (_v: any) => {});
+      });
+    } else {
+      chrome.tabs.query({ index: data.index, lastFocusedWindow: true }, (tab) => {
+        chrome.tabs.update(tab[0].id!, { active: true }, (_v: any) => {});
       });
     }
   }

--- a/src/handlers/tab-handler.ts
+++ b/src/handlers/tab-handler.ts
@@ -65,8 +65,15 @@ export default class TabHandler {
   }
 
   async COMMAND_TYPE_SWITCH_TAB(data: any): Promise<any> {
-    chrome.tabs.query({ index: data.index - 1, lastFocusedWindow: true }, (tab) => {
-      chrome.tabs.update(tab[0].id!, { active: true }, (_v: any) => {});
-    });
+    if (data.index) {
+      chrome.tabs.query({ index: data.index - 1, lastFocusedWindow: true }, (tab) => {
+        chrome.tabs.update(tab[0].id!, { active: true }, (_v: any) => {});
+      });
+    } else {
+      // Undefined index corresponds to last tab (because protobuf does not send default values)
+      chrome.tabs.query({ lastFocusedWindow: true }, (tabs) => {
+        chrome.tabs.update(tabs[tabs.length - 1].id!, { active: true }, (_v: any) => {});
+      });
+    }
   }
 }

--- a/src/handlers/tab-handler.ts
+++ b/src/handlers/tab-handler.ts
@@ -65,14 +65,9 @@ export default class TabHandler {
   }
 
   async COMMAND_TYPE_SWITCH_TAB(data: any): Promise<any> {
-    if (data.index <= 0) {
-      chrome.tabs.query({ lastFocusedWindow: true }, (tabs) => {
-        chrome.tabs.update(tabs[tabs.length - 1].id!, { active: true }, (_v: any) => {});
-      });
-    } else {
-      chrome.tabs.query({ index: data.index, lastFocusedWindow: true }, (tab) => {
-        chrome.tabs.update(tab[0].id!, { active: true }, (_v: any) => {});
-      });
-    }
+    chrome.tabs.query({ lastFocusedWindow: true }, (tabs) => {
+      const index = data.index > 0 ? data.index - 1 : tabs.length - 1;
+      chrome.tabs.update(tabs[index].id!, { active: true }, (_v: any) => {});
+    });
   }
 }


### PR DESCRIPTION
The "last tab" voice command sets the `index` of the `COMMAND_TYPE_SWITCH_TAB` command to 0. Because protobuf doesn't include default values in its messages, `data.index` was undefined and couldn't be used to switch to the correct tab. This change handles this case explicitly.