### PR TITLE
Change: Inject the script into the document's head

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -6,7 +6,7 @@
  */
 function injectScript(filePath) {
   const script = document.createElement("script");
-  script.type = 'text/javascript';
+  script.type = "text/javascript";
   script.src = filePath;
   (document.head || document.documentElement).appendChild(script);
 }

--- a/src/inject.js
+++ b/src/inject.js
@@ -1,14 +1,16 @@
 /**
- * injectScript - Inject internal script to available access to the `window`
+ * injectScript - Inject internal script into the document's head element
  *
- * @param  {type} file_path Local path of the internal script.
- * @param  {type} tag The tag as string, where the script will be append (default: 'body').
+ * @param  {string} filePath Local path of the internal script.
  * @see    {@link http://stackoverflow.com/questions/20499994/access-window-variable-from-content-script}
  */
-function injectScript(file_path) {
-  var script = document.createElement("script");
-  script.setAttribute("type", "text/javascript");
-  script.setAttribute("src", file_path);
-  document.documentElement.appendChild(script);
+function injectScript(filePath) {
+  const script = document.createElement("script");
+  script.type = 'text/javascript';
+  script.src = filePath;
+  (document.head || document.documentElement).appendChild(script);
 }
-injectScript(chrome.extension.getURL("build/page.js"));
+
+document.addEventListener("DOMContentLoaded", function() {
+  injectScript(chrome.extension.getURL("build/page.js"));
+});


### PR DESCRIPTION
Closes #41 

### Changes made to the script:

1. Fixed function documentation to represent actual parameters.
2. Changed parameter to camelCase instead of snake_case, since that's the standard for JavaScript.
3. Removed `setAttribute()` in favor of properties, since we're dealing with built-in properties.
4. Append the script to the document's `head` instead of the `html` element. I also added a fallback to append it to the `html` element, just in case.
5. Change so that the script is only added after the DOM content has loaded. So that the `head` element is available when we try to access it.

### Tested in:

Chrome 97.0.4692.99 (Official Build) (arm64)
macOS Monterey 12.1