### PR TITLE
Add popup and "Always Show Clickables" setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 *.log
 .idea
 package-lock.json
+.vscode

--- a/manifest.json
+++ b/manifest.json
@@ -5,6 +5,10 @@
   "description": "Code with voice. Learn more at https://serenade.ai.",
   "permissions": ["tabs", "scripting"],
   "host_permissions": ["ws://localhost:17373/", "*://*/*"],
+  "action": {
+    "default_title": "Serenade for Chrome",
+    "default_popup": "src/popup.html"
+  },
   "background": {
     "service_worker": "build/extension.js"
   },

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Serenade",
   "version": "2.0.0",
   "description": "Code with voice. Learn more at https://serenade.ai.",
-  "permissions": ["tabs", "scripting"],
+  "permissions": ["tabs", "scripting", "storage"],
   "host_permissions": ["ws://localhost:17373/", "*://*/*"],
   "action": {
     "default_title": "Serenade for Chrome",

--- a/src/content-script.ts
+++ b/src/content-script.ts
@@ -33,7 +33,7 @@ async function sendMessageToInjectedScript(data: any) {
 
 chrome.runtime.onMessage.addListener(async (request, _sender, sendResponse) => {
   if (request.type == "injected-script-command-request") {
-    const response = sendMessageToInjectedScript(request.data)
+    const response = await sendMessageToInjectedScript(request.data)
     sendResponse(response);
   }
   return true;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,17 +6,9 @@ const ipc = new IPC(
   navigator.userAgent.indexOf("Brave") != -1
     ? "brave"
     : navigator.userAgent.indexOf("Edg") != -1
-    ? "edge"
-    : "chrome",
+      ? "edge"
+      : "chrome",
   extensionCommandHandler
 );
-
-chrome.runtime.onMessage.addListener(
-  (message, _sender, _sendResponse) => {
-    if (message.command === "updateSettings") {
-      chrome.storage.sync.set({settings: message.data});
-    }
-  }
-)
 
 ipc.start();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,4 +11,12 @@ const ipc = new IPC(
   extensionCommandHandler
 );
 
+chrome.runtime.onMessage.addListener(
+  (message, _sender, _sendResponse) => {
+    if (message.command === "updateSettings") {
+      chrome.storage.sync.set({settings: message.data});
+    }
+  }
+)
+
 ipc.start();

--- a/src/injected-command-handler.ts
+++ b/src/injected-command-handler.ts
@@ -87,8 +87,6 @@ export default class InjectedCommandHandler {
       const item = nodes[i];
       if (item !== null && this.inViewport(item as HTMLElement)) {
         matches.push(item);
-      } else {
-        console.log(item);
       }
     }
     return matches;
@@ -385,9 +383,7 @@ export default class InjectedCommandHandler {
   }
 
   async COMMAND_TYPE_GET_EDITOR_STATE(_data: any): Promise<any> {
-    console.log(this.settings);
     if (this.settings.alwaysShowClickables) {
-      console.log(this.overlays);
       this.COMMAND_TYPE_SHOW({ text: "all" });
     }
     const editor = await editors.active();
@@ -420,7 +416,6 @@ export default class InjectedCommandHandler {
   }
 
   async COMMAND_TYPE_SHOW(data: any): Promise<any> {
-    console.log(data)
     let selector = "";
     if (data.text == "links") {
       selector = 'a, button, summary, [role="link"], [role="button"]';
@@ -433,9 +428,7 @@ export default class InjectedCommandHandler {
     } else {
       return;
     }
-    console.log(selector);
     const nodes = this.nodesMatchingSelector(selector);
-    console.log(nodes);
     this.showOverlays(Array.from(nodes), data.text);
   }
 

--- a/src/injected-command-handler.ts
+++ b/src/injected-command-handler.ts
@@ -282,7 +282,7 @@ export default class InjectedCommandHandler {
       overlay.style.position = "absolute";
       overlay.style.zIndex = "999";
       overlay.style.top = elementRect.top - bodyRect.top + "px";
-      overlay.style.left = elementRect.left - bodyRect.left + "px";
+      overlay.style.left = elementRect.left - bodyRect.left - overlay.clientWidth + "px";
       overlay.style.padding = "3px";
       overlay.style.textAlign = "center";
       overlay.style.color = "#e6ecf2";
@@ -398,8 +398,7 @@ export default class InjectedCommandHandler {
 
   async COMMAND_TYPE_GET_EDITOR_STATE(_data: any): Promise<any> {
     if (this.settings.alwaysShowClickables) {
-      await this.COMMAND_TYPE_SHOW({ text: "links" });
-      return;
+      this.COMMAND_TYPE_SHOW({ text: "links" });
     }
     const editor = await editors.active();
     if (!editor) {

--- a/src/injected-command-handler.ts
+++ b/src/injected-command-handler.ts
@@ -2,7 +2,7 @@ import * as editors from "./editors";
 
 export default class InjectedCommandHandler {
   overlays: { node: Node, type: string }[] = [];
-
+  
   private clickNode(node: Node) {
     const element = node as HTMLElement;
     if (element.className!.includes("CodeMirror")) {

--- a/src/injected-command-handler.ts
+++ b/src/injected-command-handler.ts
@@ -1,8 +1,11 @@
 import * as editors from "./editors";
 
 export default class InjectedCommandHandler {
-  overlays: { node: Node, type: string }[] = [];
-  
+  private overlays: { node: Node; type: string }[] = [];
+  private settings = {
+    alwaysShowClickables: false,
+  };
+
   private clickNode(node: Node) {
     const element = node as HTMLElement;
     if (element.className!.includes("CodeMirror")) {
@@ -33,30 +36,14 @@ export default class InjectedCommandHandler {
 
     // If all four of the corners are covered by another element that's not a parent, no need to show
     if (
-      !element.contains(
-        document.elementFromPoint(bounding.left + 1, bounding.top + 1)
-      ) &&
-      !element.contains(
-        document.elementFromPoint(bounding.right - 1, bounding.top + 1)
-      ) &&
-      !element.contains(
-        document.elementFromPoint(bounding.left + 1, bounding.bottom - 1)
-      ) &&
-      !element.contains(
-        document.elementFromPoint(bounding.right - 1, bounding.bottom - 1)
-      ) &&
-      !document
-        .elementFromPoint(bounding.left + 1, bounding.top + 1)
-        ?.contains(element) &&
-      !document
-        .elementFromPoint(bounding.right - 1, bounding.top + 1)
-        ?.contains(element) &&
-      !document
-        .elementFromPoint(bounding.left + 1, bounding.bottom - 1)
-        ?.contains(element) &&
-      !document
-        .elementFromPoint(bounding.right - 1, bounding.bottom - 1)
-        ?.contains(element)
+      !element.contains(document.elementFromPoint(bounding.left + 1, bounding.top + 1)) &&
+      !element.contains(document.elementFromPoint(bounding.right - 1, bounding.top + 1)) &&
+      !element.contains(document.elementFromPoint(bounding.left + 1, bounding.bottom - 1)) &&
+      !element.contains(document.elementFromPoint(bounding.right - 1, bounding.bottom - 1)) &&
+      !document.elementFromPoint(bounding.left + 1, bounding.top + 1)?.contains(element) &&
+      !document.elementFromPoint(bounding.right - 1, bounding.top + 1)?.contains(element) &&
+      !document.elementFromPoint(bounding.left + 1, bounding.bottom - 1)?.contains(element) &&
+      !document.elementFromPoint(bounding.right - 1, bounding.bottom - 1)?.contains(element)
     ) {
       return false;
     }
@@ -67,11 +54,7 @@ export default class InjectedCommandHandler {
         (bounding.bottom >= 0 && bounding.bottom <= window.innerHeight)) &&
       ((bounding.left >= 0 && bounding.left <= window.innerWidth) ||
         (bounding.right >= 0 && bounding.right <= window.innerWidth)) &&
-      !!(
-        element.offsetWidth ||
-        element.offsetHeight ||
-        element.getClientRects().length
-      )
+      !!(element.offsetWidth || element.offsetHeight || element.getClientRects().length)
     );
   }
 
@@ -124,15 +107,22 @@ export default class InjectedCommandHandler {
   }
 
   private elementIsScrollable(element: HTMLElement, direction: string): boolean {
-    if (direction === "up" || direction === "down" || direction === "bottom" || direction === "top") {
+    if (
+      direction === "up" ||
+      direction === "down" ||
+      direction === "bottom" ||
+      direction === "top"
+    ) {
       const overflowStyle = window.getComputedStyle(element).overflowY;
       return (
-        element.scrollHeight > element.clientHeight && (overflowStyle === "scroll" || overflowStyle === "auto")
+        element.scrollHeight > element.clientHeight &&
+        (overflowStyle === "scroll" || overflowStyle === "auto")
       );
     } else if (direction === "left" || direction === "right") {
       const overflowStyle = window.getComputedStyle(element).overflowX;
       return (
-        element.scrollWidth > element.clientWidth && (overflowStyle === "scroll" || overflowStyle === "auto")
+        element.scrollWidth > element.clientWidth &&
+        (overflowStyle === "scroll" || overflowStyle === "auto")
       );
     }
     return false;
@@ -191,13 +181,15 @@ export default class InjectedCommandHandler {
 
   private async scrollInDirection(direction: string) {
     let hoveredElements = document.querySelectorAll("*:hover");
-    let lastHoveredElement = hoveredElements.length ? hoveredElements[hoveredElements.length - 1] as HTMLElement : null;
+    let lastHoveredElement = hoveredElements.length
+      ? (hoveredElements[hoveredElements.length - 1] as HTMLElement)
+      : null;
     let scrolled = false;
     while (lastHoveredElement && !scrolled) {
       if (this.elementIsScrollable(lastHoveredElement, direction)) {
         let options = this.scrollOptions(lastHoveredElement, direction);
         if (direction === "top" || direction === "bottom") {
-          lastHoveredElement.scrollTo(options)
+          lastHoveredElement.scrollTo(options);
         } else {
           lastHoveredElement.scrollBy(options);
         }
@@ -209,7 +201,7 @@ export default class InjectedCommandHandler {
     if (!scrolled) {
       let options = this.scrollOptions(window, direction);
       if (direction === "top" || direction === "bottom") {
-        window.scrollTo(options)
+        window.scrollTo(options);
       } else {
         window.scrollBy(options);
       }
@@ -238,7 +230,7 @@ export default class InjectedCommandHandler {
     }
     // Use first match
     if (!target) {
-      target = matches[0]
+      target = matches[0];
     }
 
     const style = window.getComputedStyle(target as Element);
@@ -271,7 +263,9 @@ export default class InjectedCommandHandler {
     overlay.style.fontFamily =
       '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif';
     document.body.appendChild(overlay);
-    setTimeout(() => {document.body.removeChild(overlay)}, 1000);
+    setTimeout(() => {
+      document.body.removeChild(overlay);
+    }, 1000);
   }
 
   private showOverlays(nodes: Node[], overlayType: string) {
@@ -338,8 +332,7 @@ export default class InjectedCommandHandler {
     const pathNumber = parseInt(data.path, 10);
     if (!isNaN(pathNumber)) {
       // if path is a number, check that it is available
-      response.clickable =
-        pathNumber - 1 >= 0 && pathNumber - 1 < this.overlays.length;
+      response.clickable = pathNumber - 1 >= 0 && pathNumber - 1 < this.overlays.length;
     } else {
       // otherwise, search for matching nodes
       let matches = this.nodesMatchingPath(data.path);
@@ -404,6 +397,10 @@ export default class InjectedCommandHandler {
   }
 
   async COMMAND_TYPE_GET_EDITOR_STATE(_data: any): Promise<any> {
+    if (this.settings.alwaysShowClickables) {
+      await this.COMMAND_TYPE_SHOW({ text: "links" });
+      return;
+    }
     const editor = await editors.active();
     if (!editor) {
       return;
@@ -438,8 +435,7 @@ export default class InjectedCommandHandler {
     if (data.text == "links") {
       selector = 'a, button, summary, [role="link"], [role="button"]';
     } else if (data.text == "inputs") {
-      selector =
-        'input, textarea, [role="checkbox"], [role="radio"], .CodeMirror';
+      selector = 'input, textarea, [role="checkbox"], [role="radio"], .CodeMirror';
     } else if (data.text == "code") {
       selector = "pre, code";
     } else {
@@ -463,5 +459,14 @@ export default class InjectedCommandHandler {
       this.showCopyOverlay(data.index);
     }
     this.clearOverlays();
+  }
+
+  async updateSettings(data: any): Promise<void> {
+    this.settings = {
+      alwaysShowClickables: data.alwaysShowClickables,
+    };
+    if (!this.settings.alwaysShowClickables) {
+      this.clearOverlays();
+    }
   }
 }

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -70,17 +70,20 @@ export default class IPC {
     } catch (e) { }
   }
 
-  private async tab(): Promise<number> {
+  private async tab(): Promise<any> {
     const [result] = await chrome.tabs.query({
       active: true,
       currentWindow: true,
     });
 
-    return result.id!;
+    return result?.id;
   }
 
   private async sendMessageToContentScript(message: any): Promise<any> {
     let tabId = await this.tab();
+    if (!tabId) {
+      return;
+    }
     return new Promise((resolve) => {
       chrome.tabs.sendMessage(tabId, message, (response) => {
         resolve(response);

--- a/src/popup.css
+++ b/src/popup.css
@@ -1,0 +1,95 @@
+html {
+  min-width: 300px;
+}
+
+body {
+  font-family: aktiv-grotesk, sans-serif;
+  font-size: medium;
+  color: #475569;
+  text-align: center;
+  padding-bottom: 1em;
+}
+
+h1 {
+  font-size: x-large;
+}
+
+a {
+  color: #fff;
+  background-color: rgb(59 130 246);
+  display: inline-block;
+  text-decoration: none;
+  padding: 0.5em 1.5em;
+  margin-bottom: 1em;
+  font-weight: normal;
+  text-align: center;
+  vertical-align: middle;
+  border-radius: 1em;
+  box-shadow: 0 4px 6px -1px #3b82f688;
+}
+
+a:hover {
+  background-color: rgb(37 99 235);
+  box-shadow: 0 4px 6px -1px #3b82f688;
+}
+
+/* The switch - the box around the slider */
+.switch {
+  --width: 40px;
+  --height: calc(var(--width) / 1.8);
+  position: relative;
+  display: inline-block;
+  width: var(--width);
+  height: var(--height);
+  vertical-align: middle;
+}
+
+/* Hide default HTML checkbox */
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+/* The slider */
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgb(29 78 216);
+  -webkit-transition: 0.4s;
+  transition: 0.4s;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: calc(0.8 * var(--height));
+  width: calc(0.8 * var(--height));
+  top: calc(0.1 * var(--height));
+  left: calc(0.1 * var(--height));
+  border-radius: calc(var(--height) / 2);
+  background-color: #fff;
+  box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.3);
+  transition: 0.4s;
+}
+
+input:checked + .slider {
+  background-color: rgb(59 130 246);
+}
+
+input:focus + .slider {
+  box-shadow: 0 0 1px rgb(59 130 246);
+}
+
+input:checked + .slider:before {
+  transform: translateX(calc(var(--width) - var(--height)));
+}
+
+/* Rounded sliders */
+.slider.round {
+  border-radius: var(--height);
+}

--- a/src/popup.css
+++ b/src/popup.css
@@ -60,8 +60,6 @@ a:hover {
   right: 0;
   bottom: 0;
   background-color: rgb(29 78 216);
-  -webkit-transition: 0.4s;
-  transition: 0.4s;
 }
 
 .slider:before {
@@ -74,7 +72,6 @@ a:hover {
   border-radius: calc(var(--height) / 2);
   background-color: #fff;
   box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.3);
-  transition: 0.4s;
 }
 
 input:checked + .slider {

--- a/src/popup.css
+++ b/src/popup.css
@@ -11,7 +11,7 @@ body {
 }
 
 h1 {
-  font-size: x-large;
+  font-size: medium;
 }
 
 a {

--- a/src/popup.css
+++ b/src/popup.css
@@ -1,5 +1,5 @@
 html {
-  min-width: 300px;
+  min-width: 400px;
 }
 
 body {

--- a/src/popup.html
+++ b/src/popup.html
@@ -12,7 +12,7 @@
       <input id="showClickables" type="checkbox" />
       <span class="slider round"></span>
     </label>
-    Always show clickables
+    Always show link and input overlays
   </body>
   <script src="../build/popup.js"></script>
 </html>

--- a/src/popup.html
+++ b/src/popup.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Serenade for Chrome</title>
+    <link rel="stylesheet" href="popup.css">
+    <script src="../build/popup.js"></script>
+  </head>
+  <body>
+    <h1>Serenade for Chrome</h1>
+    <a href="https://serenade.ai/docs/chrome/">
+      Read the docs
+    </a>
+    <br/>
+    <label class="switch">
+      <input type="checkbox" />
+      <span class="slider round"></span>
+    </label>
+    Always show clickables
+  </body>
+</html>

--- a/src/popup.html
+++ b/src/popup.html
@@ -3,7 +3,6 @@
   <head>
     <title>Serenade for Chrome</title>
     <link rel="stylesheet" href="popup.css">
-    <script src="../build/popup.js"></script>
   </head>
   <body>
     <h1>Serenade for Chrome</h1>
@@ -12,9 +11,10 @@
     </a>
     <br/>
     <label class="switch">
-      <input type="checkbox" />
+      <input id="showClickables" type="checkbox"/>
       <span class="slider round"></span>
     </label>
     Always show clickables
   </body>
+  <script src="../build/popup.js"></script>
 </html>

--- a/src/popup.html
+++ b/src/popup.html
@@ -2,16 +2,14 @@
 <html>
   <head>
     <title>Serenade for Chrome</title>
-    <link rel="stylesheet" href="popup.css">
+    <link rel="stylesheet" href="popup.css" />
   </head>
   <body>
     <h1>Serenade for Chrome</h1>
-    <a href="https://serenade.ai/docs/chrome/">
-      Read the docs
-    </a>
-    <br/>
+    <a href="https://serenade.ai/docs/chrome/"> Read the docs </a>
+    <br />
     <label class="switch">
-      <input id="showClickables" type="checkbox"/>
+      <input id="showClickables" type="checkbox" />
       <span class="slider round"></span>
     </label>
     Always show clickables

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -1,13 +1,36 @@
 const showClickablesCheckbox = document.getElementById("showClickables") as HTMLInputElement;
 
-function updateSettings() {
+async function restoreSettings() {
+  chrome.storage.sync.get(
+    {
+      alwaysShowClickables: false,
+    },
+    function (settings) {
+      showClickablesCheckbox.checked = settings.alwaysShowClickables;
+    }
+  );
+}
+
+function saveSettingsAndUpdate() {
   const settings = {
     alwaysShowClickables: showClickablesCheckbox.checked,
   };
-  chrome.runtime.sendMessage({
-    command: "updateSettings",
-    data: settings,
+  chrome.storage.sync.set({
+    alwaysShowClickables: settings.alwaysShowClickables
+  });
+  chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+    if (!tabs[0].id) {
+      return;
+    }
+    chrome.tabs.sendMessage(tabs[0].id, {
+      type: "injected-script-command-request",
+      data: {
+        type: "updateSettings",
+        ...settings,
+      },
+    });
   });
 }
 
-showClickablesCheckbox?.addEventListener("change", updateSettings);
+document.addEventListener("DOMContentLoaded", restoreSettings);
+showClickablesCheckbox?.addEventListener("change", saveSettingsAndUpdate);

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -1,0 +1,13 @@
+const showClickablesCheckbox = document.getElementById("showClickables") as HTMLInputElement;
+
+function updateSettings() {
+  const settings = {
+    alwaysShowClickables: showClickablesCheckbox.checked,
+  };
+  chrome.runtime.sendMessage({
+    command: "updateSettings",
+    data: settings,
+  });
+}
+
+showClickablesCheckbox?.addEventListener("change", updateSettings);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,7 @@ module.exports = [
       extension: "./src/extension.ts",
       "content-script": "./src/content-script.ts",
       injected: "./src/injected.ts",
+      popup: "./src/popup.ts",
     },
     output: {
       path: path.resolve(__dirname, "build"),


### PR DESCRIPTION
- Added a popup page to the extension
- When "Always show clickables" is changed, the popup updates the setting with `chrome.storage.sync.set` and sends a message to the content script to update the settings in the injected script (injected scripts do not have access to `chrome.storage.sync`)
- Popup loads state of slider with `restoreSettings`
- New `DOMContentLoaded` listener in `content-script.ts` updates injected script settings so the setting is maintained across tabs
- Every editor state request checks if `settings.alwaysShowClickables` is true and shows/clears clickable overlays
<img width="318" alt="Screen Shot 2022-02-14 at 2 59 32 PM" src="https://user-images.githubusercontent.com/12766907/153961001-1b603e5e-9e59-419b-8cc4-436bd6eaaa49.png">